### PR TITLE
Introduce TypeIgnore Feature

### DIFF
--- a/ArchRuleDemo/ArchRuleDemo.csproj
+++ b/ArchRuleDemo/ArchRuleDemo.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
     <ProjectReference Include="..\Core\Core.csproj" />
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="**\TestData\*.*">
+    <Content Include="ArchRuleTests\TestData\*.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content> 
   </ItemGroup>

--- a/ArchRuleDemo/ArchRuleTests/ArchRuleExample_SystemTests.cs
+++ b/ArchRuleDemo/ArchRuleTests/ArchRuleExample_SystemTests.cs
@@ -64,7 +64,7 @@ namespace ArchRuleDemo.ArchRuleTests
             }
             
         }
-
+        [IgnoreType("ArchRuleExample.Infrastructure.InfraModule1.UI.InfraModuleUIClass2")]
         [Test]
         public void FeedbackFilter_NoChangesSinceLastBaseline_NoFeedback()
         {

--- a/ArchRuleExample/Infrastructure/InfraModule1/UI/InfraModuleUIClass1.cs
+++ b/ArchRuleExample/Infrastructure/InfraModule1/UI/InfraModuleUIClass1.cs
@@ -11,4 +11,24 @@ namespace ArchRuleExample.Infrastructure.InfraModule1.UI
             m_ForbiddenMember = forbiddenMember;
         }
     }
+
+    public class InfraModuleUIClass2
+    {
+        private readonly Module1DataClass1 m_ForbiddenMember;
+
+        public InfraModuleUIClass2(Module1DataClass1 forbiddenMember)
+        {
+            m_ForbiddenMember = forbiddenMember;
+        }
+    }
+
+    public class InfraModuleUIClass3
+    {
+        private readonly InfraModuleUIClass2 m_OkTest;
+
+        public InfraModuleUIClass3(InfraModuleUIClass2 forbiddenMember)
+        {
+            m_OkTest = forbiddenMember;
+        }
+    }
 }

--- a/Core/Analyser/GlobPatternMatcher.cs
+++ b/Core/Analyser/GlobPatternMatcher.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Lutz Boeckelmann and Contributors. MIT License - see LICENSE.txt
+
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace YADA.Core.Analyser
+{
+    /// <summary>
+    /// A simple class to match a string against a Glob Pattern
+    /// In this case it matches namespaces
+    /// a single * matches any character except '.'
+    /// a ** matches also the '.'
+    /// </summary>
+    internal class GlobPatternMatcher
+    {
+        private readonly Regex m_Pattern;
+
+        public GlobPatternMatcher(string pattern)
+        {
+            StringBuilder patternBuilder = new StringBuilder();
+                        
+            for(int i=0;i<pattern.Length; i++)
+            {
+                if(pattern[i] == '.')
+                {
+                    patternBuilder.Append("\\.");
+                }
+                else if(pattern[i] == '*')
+                {
+                    if(i<pattern.Length-1 && pattern[i+1] == '*')
+                    {
+                        i++;
+                        patternBuilder.Append(".*");
+                    }
+                    else
+                    {
+                        patternBuilder.Append("[^.]*");
+                    }
+                } else
+                {
+                    patternBuilder.Append(pattern[i]);
+                }
+            }
+            
+            m_Pattern = new Regex(patternBuilder.ToString());
+        }
+
+        public bool IsMatch(string input)
+        {
+            return m_Pattern.IsMatch(input);
+        }
+    }
+}

--- a/Core/Analyser/IgnoreTypeAttribute.cs
+++ b/Core/Analyser/IgnoreTypeAttribute.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) Lutz Boeckelmann and Contributors. MIT License - see LICENSE.txt
+
+using System;
+
+namespace YADA.Core.Analyser
+{
+
+    public enum IgnorePatternType
+    {
+        Glob,
+        Regex
+    }
+
+    public enum IgnoreTypeOptions
+    {
+        None,
+        IgnoreAlsoAsDependency
+    }
+
+    /// <summary>
+    /// This attribute can be used to configure types which should be ignored.
+    /// This works on fully qualified names and ignores assemblies at the moment.
+    /// The types can be selected by a glob or regex pattern.
+    /// 
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = true)]
+    public class IgnoreTypeAttribute : Attribute
+    {
+        /// <summary>
+        /// Constructs a filter to ignore types. The pattern is interpreted as Glob.
+        /// In this case * matches any character except .
+        /// The ** matches anything.
+        /// </summary>
+        /// <param name="pattern">Pattern of the types to ignore.</param>
+        public IgnoreTypeAttribute(string pattern) : this(pattern, IgnorePatternType.Glob)
+        {
+            
+        }
+
+        /// <summary>
+        /// Constructs a filter to ignore types.
+        /// </summary>
+        /// <param name="pattern">Pattern of the types to ignore. Could be a Glob or a RegEx</param>
+        /// <param name="patternType">Type of the pattern, Glob or Regex. Default is glob</param>
+        public IgnoreTypeAttribute(string pattern, IgnorePatternType patternType) : this(pattern, patternType, IgnoreTypeOptions.IgnoreAlsoAsDependency)
+        {
+            
+        }
+
+        /// <summary>
+        /// Constructs a filter to ignore types.
+        /// </summary>
+        /// <param name="pattern">Pattern of the types to ignore. The pattern will be interpreted as glob</param>
+        /// <param name="ignoreTypeAsDependency">Ignore the matched types also if the appear as dependency of an analyzed type</param>
+        public IgnoreTypeAttribute(string pattern, IgnoreTypeOptions ignoreTypeAsDependency) : this(pattern,IgnorePatternType.Glob, ignoreTypeAsDependency)
+        {
+            
+        }
+
+        /// <summary>
+        /// Constructs a filter to ignore types.
+        /// </summary>
+        /// <param name="pattern">Pattern of the types to ignore. Could be a Glob or a RegEx</param>
+        /// <param name="patternType">Type of the pattern, Glob or Regex. Default is glob</param>
+        /// <param name="ignoreTypeAsDependency">Ignore the matched types also if the appear as dependency of an analyzed type</param>
+        public IgnoreTypeAttribute(string pattern, IgnorePatternType patternType, IgnoreTypeOptions ignoreTypeAsDependency)
+        {
+            Pattern = pattern;
+            PatternType = patternType;
+            IgnoreTypeAsDependency = ignoreTypeAsDependency == IgnoreTypeOptions.IgnoreAlsoAsDependency ;
+        }
+
+
+        /// <summary>
+        /// Type of the pattern, Glob or Regex
+        /// </summary>
+        public IgnorePatternType PatternType { get; }
+        
+        /// <summary>
+        /// Indicates if an ignored type should also be ignored as dependency
+        /// of other types (suppressed)
+        /// </summary>
+        internal bool IgnoreTypeAsDependency { get; }
+
+        /// <summary>
+        /// The pattern to ignore
+        /// </summary>
+        internal string Pattern { get; }
+
+        
+    }
+}

--- a/Core/Analyser/TypeFilter.cs
+++ b/Core/Analyser/TypeFilter.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Lutz Boeckelmann and Contributors. MIT License - see LICENSE.txt
+
+using System.Text.RegularExpressions;
+using Mono.Cecil;
+
+namespace YADA.Core.Analyser
+{
+    internal interface ITypeFilter
+    {
+        bool IgnoreType(TypeDefinition type);
+        bool IgnoreTypeAsDependency(TypeDefinition type);
+    }
+
+    internal class GlobTypeFilter : ITypeFilter
+    {
+        private readonly GlobPatternMatcher m_Matcher;
+        private readonly bool m_IgnoreAlsoAsDependencies;
+        public GlobTypeFilter(string globPattern, bool ignoreAlsoAsDependencies)
+        {
+            m_Matcher = new GlobPatternMatcher(globPattern);
+            m_IgnoreAlsoAsDependencies = ignoreAlsoAsDependencies;
+        }
+        public bool IgnoreType(TypeDefinition type)
+        {
+            return m_Matcher.IsMatch(type.FullName);
+        }
+
+        public bool IgnoreTypeAsDependency(TypeDefinition type)
+        {
+            return m_IgnoreAlsoAsDependencies && m_Matcher.IsMatch(type.FullName);
+        }
+    }
+
+
+    internal class RegExMatcher : ITypeFilter
+    {
+        private readonly Regex m_RegEx;
+        private readonly bool m_IgnoreAlsoAsDependencies;
+
+        public RegExMatcher(string regex, bool ignoreAlsoAsDependencies) 
+        {
+            m_RegEx = new Regex(regex, RegexOptions.Compiled);
+            m_IgnoreAlsoAsDependencies = ignoreAlsoAsDependencies;
+        }
+        public bool IgnoreType(TypeDefinition type)
+        {
+            return m_RegEx.IsMatch(type.FullName);
+        }
+
+        public bool IgnoreTypeAsDependency(TypeDefinition type)
+        {
+            return m_IgnoreAlsoAsDependencies && m_RegEx.IsMatch(type.FullName);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ See the following snippet:
     // fetch all types 
     var typeDescriptions = typeLoader.GetTypes();
 
-    // iterate over all type for the analyse 
+    // iterate over all type for the analyze 
     foreach (var typeDescription in typeDescriptions)
     {
         // access the full qualified name of the current type
-        Console.WriteLine($"Full name: {typeDescription.FullName}");
-        Console.WriteLine("Dependencies of ");
+        Console.WriteLine($"Type: {typeDescription.FullName}");
+        Console.WriteLine("  Dependencies:");
 
         //iterate over all dependencies of the current type
         foreach (var typeDependency in typeDescription.Dependencies)
@@ -66,15 +66,16 @@ As you can see with under 10 lines of code you can generate some insights about 
 Executing the code produces the following output:
 ```bash
 ...
-Full name: Example.StaticProvider2
-Dependencies of 
-    - System.Int32
+Type: Example.Example1
+  Dependencies:
+    - Example.Dependency1
     - System.Object
-Full name: Example.ClassWithMethodUsingStaticReferences
-Dependencies of 
+Type: Example.Dependency1
+  Dependencies:
     - System.Object
-    - Example.StaticProvider
-    - Example.IDependencyInterface
+Type: Example.Dependency2
+  Dependencies:
+    - System.Object
 ...
 ```
 
@@ -92,6 +93,11 @@ Dependencies will be searched at the following ways:
   
 Any found dependency will be added to the ITypeDescription together with the IDependencyContext containing information about the occurrence. Any needed information will be retrieved during this step and stored in the result set.
 
+If not any type should be analyzed it is possible to ignore them directly during the type loading. This can be done with the **YADA.Core.Analyser.IgnoreType** Attribute.
+This has to be added above one method in the call stack which creates the typeloader. No only the type will be removed from the result set also
+any dependency to this type in other types are ignored.
+In the example above ```[IgnoreType("**.*Dependency*")]``` will remove any class containing **Dependency** in the name or as part of a namespace.
+
 ### Testability as first class citizen
 
 Any complex logic needs tests. And creating tests for input data fetched from assemblies is not the right way. So any interface in YADA uses only plain c# types, which provides a simple way to test your application with Fakes. In fact there are simple fake implementations for ITypeDescription and IDependency available.
@@ -104,7 +110,7 @@ The *IDependencyContext* self is a nearly empty class, but it can be visited by 
 
 ## Automate architectural rules
 
-With the Core mechanisms of *YADA* described above it is possible to create own automated tests. A way to do this is provided with the rule engine, which can be found under . [*YADA.DependencyRuleEngine*](./core/DependencyRuleEngine/Readme.md).
+With the Core mechanisms of *YADA* described above it is possible to create own automated tests. A way to do this is provided with the rule engine, which can be found under. [*YADA.DependencyRuleEngine*](./core/DependencyRuleEngine/Readme.md).
 
 ##  Filtering the results
 

--- a/Test/BaseLayerTests.cs
+++ b/Test/BaseLayerTests.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Lutz Boeckelmann and Contributors. MIT License - see LICENSE.txt
+
 using System.Collections.Generic;
 using Core.DependencyRuleEngine.Rules;
 using NUnit.Framework;

--- a/Test/BlacklistIgnoreTypeRuleTests.cs
+++ b/Test/BlacklistIgnoreTypeRuleTests.cs
@@ -1,3 +1,4 @@
+// Copyright (c) Lutz Boeckelmann and Contributors. MIT License - see LICENSE.txt
 
 using NUnit.Framework;
 using YADA.Core.Analyser;

--- a/Test/DependencyRuleResultAggregationTest.cs
+++ b/Test/DependencyRuleResultAggregationTest.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Lutz Boeckelmann and Contributors. MIT License - see LICENSE.txt
+
 using NUnit.Framework;
 using YADA.Core.DependencyRuleEngine;
 

--- a/Test/FeedbackCollectorTests.cs
+++ b/Test/FeedbackCollectorTests.cs
@@ -1,7 +1,5 @@
 // Copyright (c) Lutz Boeckelmann and Contributors. MIT License - see LICENSE.txt
 
-
-using System.Text;
 using YADA.Core.DependencyRuleEngine.Feedback;
 using NUnit.Framework;
 

--- a/Test/FirstSimpleExample.cs
+++ b/Test/FirstSimpleExample.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Lutz Boeckelmann and Contributors. MIT License - see LICENSE.txt
+
 using System;
 using NUnit.Framework;
 using YADA.Core.Analyser;
@@ -8,6 +10,7 @@ namespace Test
     public class FirstSimpleExample
     {
         [Test]
+        [IgnoreType("**.*Dependency*")]
         public void Simple_Way_To_List_All_Dependencies_In_ExampleDll() 
         {
             // creating the type loader and load all types from the example dll
@@ -16,12 +19,12 @@ namespace Test
             // fetch all types 
             var typeDescriptions = typeLoader.GetTypes();
 
-            // iterate over all type for the analyse 
+            // iterate over all type for the analyze 
             foreach (var typeDescription in typeDescriptions)
             {
                 // access the full qualified name of the current type
-                Console.WriteLine($"Full name: {typeDescription.FullName}");
-                Console.WriteLine("Dependencies of ");
+                Console.WriteLine($"Type: {typeDescription.FullName}");
+                Console.WriteLine("  Dependencies:");
 
                 //iterate over all dependencies of the current type
                 foreach (var typeDependency in typeDescription.Dependencies)

--- a/Test/GlobbingTests.cs
+++ b/Test/GlobbingTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Lutz Boeckelmann and Contributors. MIT License - see LICENSE.txt
+
+using NUnit.Framework;
+using YADA.Core.Analyser;
+
+namespace YADA.Test
+{
+    [TestFixture]
+    public class GlobbingTests
+    {
+        [Test]
+        public void IsMatch_InputEqualsPatter_True()
+        {
+            GlobPatternMatcher sut = new GlobPatternMatcher("Test");
+            var result = sut.IsMatch("Test");
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void IsMatch_InputContainsPattern_True()
+        {
+            GlobPatternMatcher sut = new GlobPatternMatcher("Test");
+            var result = sut.IsMatch("SomeImputTestSomethingMore");
+            Assert.IsTrue(result);
+        }
+        [Test]
+        public void IsMatch_UnMatchingInput_False()
+        {
+            GlobPatternMatcher sut = new GlobPatternMatcher("Test");
+            var result = sut.IsMatch("SomeImputWithoutAnyPatternSomethingMore");
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void IsMatch_StarMatchesAnything()
+        {
+            GlobPatternMatcher sut = new GlobPatternMatcher("*");
+            var result = sut.IsMatch("SomeImputWithPatternSomethingMore");
+            Assert.IsTrue(result);
+        }
+
+        [TestCase("SomeImputWithPatternWithDotSomethingMore", true)]
+        [TestCase("SomeImputWithPatternGWithDotthingMore", false)]
+        public void IsMatch_StarExpanseUntilBlocked(string input, bool expected)
+        {
+            GlobPatternMatcher sut = new GlobPatternMatcher("Pa*Some");
+            var result = sut.IsMatch(input);
+            Assert.That(result, Is.EqualTo(expected));
+        }
+
+        [TestCase("SomeImputWithPattern.WithDotSomethingMore", true)]
+        [TestCase("SomeImputWithPatternGWithDotSomethingMore", false)]
+        public void IsMatch_DotIsMatchedOnlyAsDot(string input, bool expected) 
+        {
+            GlobPatternMatcher sut = new GlobPatternMatcher("Pattern.WithDot");
+            var result = sut.IsMatch(input);
+            Assert.That(result, Is.EqualTo(expected));
+        }
+
+
+        [TestCase("SomeImput.WithPatternSomething.More", true)]
+        [TestCase("SomeImput.WithPattern.Something.More", false)]
+        public void IsMatch_DotStopsStar(string input, bool expected)
+        {
+            GlobPatternMatcher sut = new GlobPatternMatcher("With*Some");
+            var result = sut.IsMatch(input);
+            Assert.That(result, Is.EqualTo(expected));
+        }
+
+        [TestCase("SomeImput.WithPattern.Something.More", true)]
+        [TestCase("SomeImput.With.Pattern.Something.More", true)]
+        [TestCase("SomeImput.With...Pa ttern.Something.More", true)]
+        public void IsMatch_DoubleStarIsNotBlockedByDots(string input, bool expected)
+        {
+            GlobPatternMatcher sut = new GlobPatternMatcher("With**Some");
+            var result = sut.IsMatch(input);
+            Assert.That(result, Is.EqualTo(expected));
+        }
+
+        [TestCase("Example.Example1", true)]
+        public void IsMatch_DoubleStarIsNotBlockedByDots1(string input, bool expected)
+        {
+            GlobPatternMatcher sut = new GlobPatternMatcher("Example.Example1");
+            var result = sut.IsMatch(input);
+            Assert.That(result, Is.EqualTo(expected));
+        }
+
+    }
+}

--- a/Test/TypeLoaderTests.cs
+++ b/Test/TypeLoaderTests.cs
@@ -375,6 +375,39 @@ namespace YADA.Test
             Assert.That(assemblyName.First, Is.EqualTo(expectedName));
         }
 
+        [IgnoreType("Example.Example1")]
+        [Test]
+        public void TypeLoader_Types_Can_Be_Ignored()
+        {
+            var sut = new TypeLoader(new[] { @"./YADA.Example.dll" });
+            var types = sut.GetTypes();
+
+            Assert.That(types.Any(t => t.FullName == "Example.Example1"), Is.False);
+        }
+
+        [IgnoreType("**Example*")]
+        [Test]
+        public void TypeLoader_Types_Can_Be_Ignored2()
+        {
+            var sut = new TypeLoader(new[] { @"./YADA.Example.dll" });
+            var types = sut.GetTypes();
+            var l = types.Select(t => t.FullName).ToList();
+            Assert.That(types.Any(t => t.FullName.Contains("Example")), Is.False);
+        }
+
+
+
+        [IgnoreType("Example.Dependency1", IgnoreTypeOptions.IgnoreAlsoAsDependency)]
+        [Test]
+        public void TypeLoader_Ignored_Types_Does_Not_Appear_As_Dependencies_Of_Other_Types()
+        {
+            var sut = new TypeLoader(new[] { @"./YADA.Example.dll" });
+            var types = sut.GetTypes();
+            var result = types.First(t => t.FullName == "Example.Example1");
+            
+            Assert.That(result.Dependencies.Any(d => d.Type.FullName == "Example.Dependency1"), Is.False);
+        }
+
         private void PrintType(ITypeDescription type)
         {
             TestContext.WriteLine(type.FullName);

--- a/Test/WhitelistIgnoreTypeRuleTests.cs
+++ b/Test/WhitelistIgnoreTypeRuleTests.cs
@@ -1,3 +1,5 @@
+// Copyright (c) Lutz Boeckelmann and Contributors. MIT License - see LICENSE.txt
+
 using NUnit.Framework;
 using YADA.Core.Analyser;
 using YADA.Core.DependencyRuleEngine;


### PR DESCRIPTION
with the IgnoreType attribute provides the possiblity to skip types defined by a glob or regex pattern.

Additionally some rules where added to the rule engine with the same idea. With Black/ Whitelist rules types may be excluded in the rule engines. This makes it posssible to document the exluded type in the output. In opposite the IgnoreType simple skips the type at directly in the analyzer.